### PR TITLE
Nd restart new game

### DIFF
--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -89,7 +89,7 @@ const App = () => {
 			)}
 			{gameOver && (
 				<section className='play-again-section'>
-					<button onClick={startQuiz}>Restart</button>
+					<button onClick={startQuiz}>Start New Game</button>
 					<button>Save</button>
 				</section>
 			)}

--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -19,6 +19,8 @@ const App = () => {
 		setLoading('Loading your InstaQuiz...');
 		setError('');
 		setGameOver(false);
+		setUserAnswers([]);
+		setCurrentQuestionNum(1);
 
 		try {
 			const newQuizQuestions = await getQuizQuestions(15, Difficulty.EASY);
@@ -87,7 +89,7 @@ const App = () => {
 			)}
 			{gameOver && (
 				<section className='play-again-section'>
-					<button>Restart</button>
+					<button onClick={startQuiz}>Restart</button>
 					<button>Save</button>
 				</section>
 			)}


### PR DESCRIPTION
### What’s this PR do?  
- Allows a user to start a new game when they click on the start new game button
- Changed Restart to Start New Game, as a user is not restarting the same game and starting a full new game.
- Cleared other states that were affecting Start New Game from working as intended.
 
### Where should the reviewer start?  
- App.tsx
 
### How should this be manually tested?  
- `npm start` -> localhost:3000
- Fully play through a game, try to answer multiple questions along the way and the last question after the game has finished for error handling.
- When the Start New Game section appears, click on it to ensure that a new game starts.
- Check state in dev panel to ensure that currentQuestionNum resets back to 1, userAnswers array is cleared, and the display is updated back to question 1 / 15.
- Play through a 2nd time, checking error handling still works, and try to restart a 3rd one.
 
### Any background context you want to provide?  
- This branch now fully completes a user being able to start a new game and issue #3 will be closed along with this branch.
 
### What are the relevant tickets?  
- closes #35 
- closes #3