### PR TITLE
Nd refactor app start game

### DIFF
--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -103,9 +103,6 @@ const App = () => {
 								{questions.length < 1 && (
 									<button onClick={startQuiz}>Start a New InstaQuiz</button>
 								)}
-								{questions.length < 1 && (
-									<h1>Click on the button above to test a Question</h1>
-								)}
 								{error && <h1>{error}</h1>}
 								{loading && <h1>{loading}</h1>}
 								{questions.length > 0 && (

--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -100,7 +100,9 @@ const App = () => {
 								<section>
 									<Link to='/saved'>View Saved Quizzes</Link>
 								</section>
-								<button onClick={startQuiz}>Start a New InstaQuiz</button>
+								{questions.length < 1 && (
+									<button onClick={startQuiz}>Start a New InstaQuiz</button>
+								)}
 								{questions.length < 1 && (
 									<h1>Click on the button above to test a Question</h1>
 								)}

--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -17,7 +17,7 @@ const App = () => {
 	const [questions, setQuestions] = useState<QuizQuestionModel[]>([]);
 	const [userAnswers, setUserAnswers] = useState<UserAnswerModel[]>([]);
 	const [currentQuestionNum, setCurrentQuestionNum] = useState(1);
-	const [questionCount] = useState(15);
+	const [questionCount, setQuestionCount] = useState(0);
 	const [gameOver, setGameOver] = useState(false);
 	const [error, setError] = useState('');
 	const [loading, setLoading] = useState('');
@@ -31,8 +31,10 @@ const App = () => {
 		setCurrentQuestionNum(1);
 
 		try {
-			const newQuizQuestions = await getQuizQuestions(15, Difficulty.EASY);
-			setQuestions(newQuizQuestions);
+			await getQuizQuestions(15, Difficulty.EASY).then(data => {
+				setQuestions(data);
+				setQuestionCount(data.length);
+			});
 			setLoading('');
 			setError('');
 		} catch (_err) {


### PR DESCRIPTION
### What’s this PR do?  
- Modifies questionCount to be set during the fetch call in a `.then()` chain to allow for easier testing, and eventually a user setting their own question count.
- Removes heading for a user to click on the Start a new InstaQuiz button to start the game.
- Conditionally renders the Start a new InstaQuiz button to only show if there are no questions loaded in state.
 
### Where should the reviewer start?  
- git pull this branch.
- App.tsx
 
### How should this be manually tested?  
- `npm start` -> localhost:3000
- Starting a new game without changing anything should stay with 15 questions.
- Change the number inside getQuizQuestions for the number of questions to get from server and check the max question count when a new quiz starts.
- Run through a quiz with the default 15 questions and with a lower/higher question amount to ensure it works as before.
 
### Any background context you want to provide?  
- N/A
 
### What are the relevant tickets?  
- closes #46